### PR TITLE
Use error exit code on failure.

### DIFF
--- a/src/XdtTransform/Program.cs
+++ b/src/XdtTransform/Program.cs
@@ -21,10 +21,12 @@ namespace XdtTransform
                 catch (XdtTransformException tex)
                 {
                     Console.WriteLine("Error transforming file: {0}", tex.Message);
+                    Environment.Exit(1);
                 }
                 catch (Exception ex)
                 {
                     Console.WriteLine("Unexpected exception: {0}", ex.Message);
+                    Environment.Exit(1);
                 }
             }
             Environment.Exit(0);


### PR DESCRIPTION
TFS can't detect transform failure because the program now always indicates success.